### PR TITLE
Ensure all participant deployments are destroyed

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,33 +101,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: 'Run terraform'
         id: runterraform
-        run: |
-          terraform init
-          terraform apply -auto-approve
-          EDC_HOST=$(terraform output -raw edc_host)
-          echo "EDC_HOST=$EDC_HOST" >> $GITHUB_ENV
-          echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
-        working-directory: deployment/terraform
-        env:
-
-          # Authentication settings for Terraform AzureRM provider
-          # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
-          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-
-          # Terraform variables
-          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
-          TF_VAR_acr_name: ${{ secrets.ACR_NAME }}
-          TF_VAR_participant_name: ${{ matrix.participant }}
-          TF_VAR_prefix: ${{ github.run_number }}
-          TF_VAR_resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
-          TF_VAR_runtime_image: mvd-edc/connector:${{ github.run_number }}
-          TF_VAR_application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}
-
-      - name: 'Verify deployed EDC is healthy'
-        run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
+        run: echo "coucou"
 
   Verify:
     needs: Deploy

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -140,6 +140,7 @@ jobs:
 
   # Delete deployed Azure resource groups for each dataspace participant.
   Destroy:
+    continue-on-error: true
     needs: [Deploy, Verify]
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,7 +101,33 @@ jobs:
       - uses: actions/checkout@v2
       - name: 'Run terraform'
         id: runterraform
-        run: echo "coucou"
+        run: |
+          terraform init
+          terraform apply -auto-approve
+          EDC_HOST=$(terraform output -raw edc_host)
+          echo "EDC_HOST=$EDC_HOST" >> $GITHUB_ENV
+          echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
+        working-directory: deployment/terraform
+        env:
+
+          # Authentication settings for Terraform AzureRM provider
+          # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+          # Terraform variables
+          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
+          TF_VAR_acr_name: ${{ secrets.ACR_NAME }}
+          TF_VAR_participant_name: ${{ matrix.participant }}
+          TF_VAR_prefix: ${{ github.run_number }}
+          TF_VAR_resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
+          TF_VAR_runtime_image: mvd-edc/connector:${{ github.run_number }}
+          TF_VAR_application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}
+
+      - name: 'Verify deployed EDC is healthy'
+        run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
 
   Verify:
     needs: Deploy


### PR DESCRIPTION
Fix bug: https://github.com/agera-edc/MinimumViableDataspace/issues/48
Make sure that if one destroy job fails, the other destroy job still run.
Tested on this run: https://github.com/agera-edc/MinimumViableDataspace/runs/6010363033?check_suite_focus=true
We can see that the 2 destroy job run.