### PR TITLE
Avoid keyvault secret name conflict between workflow reruns

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -164,6 +164,14 @@ jobs:
           chmod -R u+x .terraform/providers
           terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform
+        env:
+          # Authentication settings for Terraform AzureRM provider
+          # See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
 
       - uses: actions/upload-artifact@v3
         name: 'Remove terraform artifact'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -103,13 +103,14 @@ jobs:
         id: runterraform
         run: |
           echo '
-          acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
-          acr_name = "${{ secrets.ACR_NAME }}"
-          participant_name = "${{ matrix.participant }}"
-          prefix = "${{ github.run_number }}"
-          resource_group = "rg-${{ matrix.participant }}-${{ github.run_number }}"
-          runtime_image = "mvd-edc/connector:${{ github.run_number }}"
-          application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"' >> input.tfvars
+            acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
+            acr_name = "${{ secrets.ACR_NAME }}"
+            participant_name = "${{ matrix.participant }}"
+            prefix = "${{ github.run_number }}"
+            resource_group = "rg-${{ matrix.participant }}-${{ github.run_number }}"
+            runtime_image = "mvd-edc/connector:${{ github.run_number }}"
+            application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
+          ' >> input.tfvars
           terraform init
           terraform apply -var-file=input.tfvars -auto-approve
           EDC_HOST=$(terraform output -raw edc_host)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -132,6 +132,7 @@ jobs:
         with:
           name: terraform-${{ matrix.participant }}
           path: deployment/terraform
+          retention-days: 1
 
       - name: 'Verify deployed EDC is healthy'
         run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -126,6 +126,12 @@ jobs:
           TF_VAR_runtime_image: mvd-edc/connector:${{ github.run_number }}
           TF_VAR_application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}
 
+      - uses: actions/upload-artifact@v3
+        name: 'Publish terraform folder'
+        with:
+          name: terraform-${{ matrix.participant }}
+          path: deployment/terraform # or path/to/artifact
+
       - name: 'Verify deployed EDC is healthy'
         run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
 
@@ -148,14 +154,20 @@ jobs:
         participant: [company1, company2]
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: 'Az CLI login'
-        uses: azure/login@v1
+      - uses: actions/download-artifact@v3
+        name: 'Publish terraform folder'
         with:
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          name: terraform-${{ matrix.participant }}
+          path: deployment/terraform
 
-      - name: 'Delete resource group'
-        run: az group delete --name rg-${{matrix.participant}}-${{ github.run_number }} --no-wait --yes
+      - name: 'Delete terraform resources'
+        run: terraform destroy -auto-approve
+
+      - uses: actions/upload-artifact@v3
+        name: 'Remove terraform artifact'
+        with:
+          name: terraform-${{ matrix.participant }}
+          path: /dev/null
+
+
+

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - uses: actions/download-artifact@v3
-        name: 'Publish terraform folder'
+        name: 'Download terraform folder'
         with:
           name: terraform-${{ matrix.participant }}
           path: deployment/terraform

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -102,8 +102,16 @@ jobs:
       - name: 'Run terraform'
         id: runterraform
         run: |
+          echo "
+          acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
+          acr_name: ${{ secrets.ACR_NAME }}
+          participant_name: ${{ matrix.participant }}
+          prefix: ${{ github.run_number }}
+          resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
+          runtime_image: mvd-edc/connector:${{ github.run_number }}
+          application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}" >> input.tfvars
           terraform init
-          terraform apply -auto-approve
+          terraform apply -var-file=input.tfvars -auto-approve
           EDC_HOST=$(terraform output -raw edc_host)
           echo "EDC_HOST=$EDC_HOST" >> $GITHUB_ENV
           echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
@@ -116,15 +124,6 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-
-          # Terraform variables
-          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
-          TF_VAR_acr_name: ${{ secrets.ACR_NAME }}
-          TF_VAR_participant_name: ${{ matrix.participant }}
-          TF_VAR_prefix: ${{ github.run_number }}
-          TF_VAR_resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
-          TF_VAR_runtime_image: mvd-edc/connector:${{ github.run_number }}
-          TF_VAR_application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}
 
       - uses: actions/upload-artifact@v3
         name: 'Publish terraform folder'
@@ -161,7 +160,7 @@ jobs:
           path: deployment/terraform
 
       - name: 'Delete terraform resources'
-        run: terraform destroy -auto-approve
+        run: terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -160,7 +160,9 @@ jobs:
           path: deployment/terraform
 
       - name: 'Delete terraform resources'
-        run: terraform destroy -var-file=input.tfvars -auto-approve
+        run: |
+          chmod -R u+x .terraform/providers
+          terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -195,6 +195,8 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+          # Override terraform values defined in file input.tfvars
+          TF_VAR_key_file=/dev/null
 
       - uses: actions/upload-artifact@v3
         name: 'Clear terraform artifact'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -190,7 +190,7 @@ jobs:
 
 
       - uses: actions/upload-artifact@v3
-        name: 'Remove terraform artifact'
+        name: 'Clear terraform artifact'
         with:
           name: terraform-${{ matrix.participant }}
           path: /dev/null

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -125,6 +125,7 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+      # Publish terraform folder because it contains the state, the provider builds and the input.tfvars file
       - uses: actions/upload-artifact@v3
         name: 'Publish terraform folder'
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -102,14 +102,14 @@ jobs:
       - name: 'Run terraform'
         id: runterraform
         run: |
-          echo "
-          acr_resource_group = ${{ secrets.COMMON_RESOURCE_GROUP }}
-          acr_name = ${{ secrets.ACR_NAME }}
-          participant_name = ${{ matrix.participant }}
-          prefix = ${{ github.run_number }}
-          resource_group = rg-${{ matrix.participant }}-${{ github.run_number }}
-          runtime_image = mvd-edc/connector:${{ github.run_number }}
-          application_sp_object_id = ${{ secrets.APP_OBJECT_ID }}" >> input.tfvars
+          echo '
+          acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
+          acr_name = "${{ secrets.ACR_NAME }}"
+          participant_name = "${{ matrix.participant }}"
+          prefix = "${{ github.run_number }}"
+          resource_group = "rg-${{ matrix.participant }}-${{ github.run_number }}"
+          runtime_image = "mvd-edc/connector:${{ github.run_number }}"
+          application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"' >> input.tfvars
           terraform init
           terraform apply -var-file=input.tfvars -auto-approve
           EDC_HOST=$(terraform output -raw edc_host)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -130,7 +130,7 @@ jobs:
         name: 'Publish terraform folder'
         with:
           name: terraform-${{ matrix.participant }}
-          path: deployment/terraform # or path/to/artifact
+          path: deployment/terraform
 
       - name: 'Verify deployed EDC is healthy'
         run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -162,6 +162,7 @@ jobs:
 
       - name: 'Delete terraform resources'
         run: terraform destroy -auto-approve
+        working-directory: deployment/terraform
 
       - uses: actions/upload-artifact@v3
         name: 'Remove terraform artifact'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -103,13 +103,13 @@ jobs:
         id: runterraform
         run: |
           echo "
-          acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
-          acr_name: ${{ secrets.ACR_NAME }}
-          participant_name: ${{ matrix.participant }}
-          prefix: ${{ github.run_number }}
-          resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
-          runtime_image: mvd-edc/connector:${{ github.run_number }}
-          application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}" >> input.tfvars
+          acr_resource_group = ${{ secrets.COMMON_RESOURCE_GROUP }}
+          acr_name = ${{ secrets.ACR_NAME }}
+          participant_name = ${{ matrix.participant }}
+          prefix = ${{ github.run_number }}
+          resource_group = rg-${{ matrix.participant }}-${{ github.run_number }}
+          runtime_image = mvd-edc/connector:${{ github.run_number }}
+          application_sp_object_id = ${{ secrets.APP_OBJECT_ID }}" >> input.tfvars
           terraform init
           terraform apply -var-file=input.tfvars -auto-approve
           EDC_HOST=$(terraform output -raw edc_host)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -196,7 +196,7 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
           # Override terraform values defined in file input.tfvars
-          TF_VAR_key_file=/dev/null
+          TF_VAR_key_file: /dev/null
 
       - uses: actions/upload-artifact@v3
         name: 'Clear terraform artifact'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -177,7 +177,7 @@ jobs:
       - name: 'Delete terraform resources'
         run: |
           : # Make terraform provider binaries executable because file permissions of uploaded artifacts are not maintained.
-          chmod -R u+x .terraform/providers
+          chmod -R +x .terraform/providers
           terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform
         env:
@@ -194,6 +194,3 @@ jobs:
         with:
           name: terraform-${{ matrix.participant }}
           path: /dev/null
-
-
-

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -176,6 +176,7 @@ jobs:
 
       - name: 'Delete terraform resources'
         run: |
+          : # Make terraform provider binaries executable because file permissions of uploaded artifacts are not maintained.
           chmod -R u+x .terraform/providers
           terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -8,7 +8,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = true
+    }
+  }
 }
 
 data "azurerm_subscription" "current_subscription" {


### PR DESCRIPTION
When triggering the pipeline twice, the second run fails because when deleting the resource group, the Keyvault is self deleted and the secrets stored in the Keyvault still exist. There is a conflict in the second run because the secret already exists.

This PR makes sure the secret is deleted by enabling purge_soft_delete_on_destroy config so that secret are deleted on destroy.

This PR fixed this bug: https://github.com/agera-edc/MinimumViableDataspace/issues/46