### PR TITLE
Feature/34 connector cert

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,6 +99,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: 'Generate key'
+        run: |
+          openssl ecparam -name prime256v1 -genkey -noout -out key.pem
+          openssl ec -in key.pem -pubout -out key.public.pem
+          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < key.public.pem > key.public.jwk
+
       - name: 'Run terraform'
         id: runterraform
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -178,4 +178,3 @@ jobs:
 
       - name: 'Delete resource group'
         run: az group delete --name rg-${{matrix.participant}}-${{ github.run_number }} --no-wait --yes
-

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -178,3 +178,4 @@ jobs:
 
       - name: 'Delete resource group'
         run: az group delete --name rg-${{matrix.participant}}-${{ github.run_number }} --no-wait --yes
+

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -115,3 +115,12 @@ resource "azurerm_key_vault_secret" "asset_storage_key" {
     azurerm_role_assignment.current-user-secretsofficer
   ]
 }
+
+resource "azurerm_key_vault_secret" "asset_storage_key" {
+  name         = var.participant_name
+  value        = file(var.key_file)
+  key_vault_id = azurerm_key_vault.participant.id
+  depends_on = [
+    azurerm_role_assignment.current-user-secretsofficer
+  ]
+}

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_key_vault_secret" "asset_storage_key" {
   ]
 }
 
-resource "azurerm_key_vault_secret" "asset_storage_key" {
+resource "azurerm_key_vault_secret" "did_key" {
   name         = var.participant_name
   value        = file(var.key_file)
   key_vault_id = azurerm_key_vault.participant.id

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -37,3 +37,8 @@ variable "container_memory" {
 variable "application_sp_object_id" {
   description = "id of application's service principal object"
 }
+
+variable "key_file" {
+  description = "name of a file containing the private key in PEM format"
+  default = "../../key.pem"
+}


### PR DESCRIPTION
Generate a private key and upload it to the connector's key vault.

In a follow up task we will also use the public key in the DID document (web endpoint), and the private key for signing JWT tokens.

Closes agera-edc/MinimumViableDataspaceFork#112 