### PR TITLE
Feature/60 contract negotiation test

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -1,0 +1,43 @@
+name: "Setup Gradle"
+description: "Setup Gradle"
+runs:
+  using: "composite"
+  steps:
+    # Checkout EDC code into DataSpaceConnector directory.
+    - name: Checkout EDC
+      uses: actions/checkout@v2
+      with:
+        repository: eclipse-dataspaceconnector/DataSpaceConnector
+        path: DataSpaceConnector
+        ref: milestone-3.1 # tag or commit hash
+
+    # Install Java and cache MVD Gradle build.
+    - uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'gradle'
+
+    # Cache EDC packages (installed into ~/.m2) in-between runs.
+    # If the latest EDC commit ID has not changed since the last run, this will restore
+    # its Maven packages from the cache.
+    - name: Cache EDC packages
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: ~/.m2
+        # .git/FETCH_HEAD contains latest commit ID
+        key: ${{ runner.os }}-m2-${{ hashFiles('DataSpaceConnector/.git/FETCH_HEAD') }}
+
+    # Install EDC packages into ~/.m2.
+    # This action only runs if the packages could not be restored from the cache.
+    - name: Build EDC packages
+      run: |
+        ./gradlew publishToMavenLocal
+      if: steps.cache.outputs.cache-hit != 'true' # only on cache miss
+      shell: bash
+      working-directory: DataSpaceConnector
+
+    - name: Delete EDC packages
+      run: rm -r DataSpaceConnector
+      shell: bash

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,53 +18,16 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      # Checkout MVD code into MVD directory.
+      # Checkout MVD code
       - uses: actions/checkout@v2
-        with:
-          path: MVD
 
-      # Checkout EDC code into DataSpaceConnector directory.
-      - name: Checkout EDC
-        uses: actions/checkout@v2
-        with:
-          repository: eclipse-dataspaceconnector/DataSpaceConnector
-          path: DataSpaceConnector
-          ref: milestone-3 # tag or commit hash
-
-      # Install Java and cache MVD Gradle build.
-      - uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      # Cache EDC packages (installed into ~/.m2) in-between runs.
-      # If the latest EDC commit ID has not changed since the last run, this will restore
-      # its Maven packages from the cache.
-      - name: Cache EDC packages
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.m2
-          # .git/FETCH_HEAD contains latest commit ID
-          key: ${{ runner.os }}-m2-${{ hashFiles('DataSpaceConnector/.git/FETCH_HEAD') }}
-
-      # Install EDC packages into ~/.m2.
-      # This action only runs if the packages could not be restored from the cache.
-      - name: Build EDC packages
-        run: |
-          chmod +x ./gradlew
-          ./gradlew publishToMavenLocal
-        if: steps.cache.outputs.cache-hit != 'true' # only on cache miss
-        working-directory: DataSpaceConnector
+      - uses: ./.github/actions/gradle-setup
 
       # Build MVD runtime JAR locally.
       # The result is a JAR file in MVD/launcher/build/libs.
       - name: 'Build runtime JAR'
         run: |
-          chmod +x ./gradlew
           ./gradlew launcher:shadowJar
-        working-directory: MVD
 
       - name: 'Az CLI login'
         uses: azure/login@v1
@@ -81,7 +44,7 @@ jobs:
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
         run: az acr build --registry $ACR_NAME --image mvd-edc/connector:${{ github.run_number }} .
-        working-directory: MVD/launcher
+        working-directory: launcher
         env:
           ACR_NAME: ${{ secrets.ACR_NAME }}
 
@@ -159,10 +122,17 @@ jobs:
     needs: Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: 'Verify EDCs are ready'
+      # Checkout MVD code
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/gradle-setup
+
+      - name: 'System tests'
         run: |
-          curl --retry 6 --fail http://${{ needs.Deploy.outputs.company1_edc_host }}:8181/api/check/health
-          curl --retry 6 --fail http://${{ needs.Deploy.outputs.company2_edc_host }}:8181/api/check/health
+          ./gradlew :system-tests:test
+        env:
+          CONSUMER_URL: http://${{ needs.Deploy.outputs.company1_edc_host }}:9191
+          PROVIDER_URL: http://${{ needs.Deploy.outputs.company2_edc_host }}:8282
 
   # Delete deployed Azure resource groups for each dataspace participant.
   Destroy:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,4 +11,11 @@ allprojects {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
         }
     }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+        testLogging {
+            showStandardStreams = true
+        }
+    }
 }

--- a/deployment/data/MVD.postman_collection.json
+++ b/deployment/data/MVD.postman_collection.json
@@ -67,7 +67,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n    \"permissions\": [\n        {\n            \"edctype\": \"dataspaceconnector:permission\",\n            \"uid\": null,\n            \"target\": \"test-document\",\n            \"action\": {\n                \"type\": \"USE\",\n                \"includedIn\": null,\n                \"constraint\": null\n            },\n            \"assignee\": null,\n            \"assigner\": null,\n            \"constraints\": [],\n            \"duties\": []\n        }\n    ],\n    \"prohibitions\": [],\n    \"obligations\": [],\n    \"extensibleProperties\": {},\n    \"inheritsFrom\": null,\n    \"assigner\": null,\n    \"assignee\": null,\n    \"target\": null,\n    \"@type\": {\n        \"@policytype\": \"set\"\n    }\n}",
+							"raw": "{\n    \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n    \"permissions\": [\n        {\n            \"edctype\": \"dataspaceconnector:permission\",\n            \"uid\": null,\n            \"target\": \"text-document\",\n            \"action\": {\n                \"type\": \"USE\",\n                \"includedIn\": null,\n                \"constraint\": null\n            },\n            \"assignee\": null,\n            \"assigner\": null,\n            \"constraints\": [],\n            \"duties\": []\n        }\n    ],\n    \"prohibitions\": [],\n    \"obligations\": [],\n    \"extensibleProperties\": {},\n    \"inheritsFrom\": null,\n    \"assigner\": null,\n    \"assignee\": null,\n    \"target\": null,\n    \"@type\": {\n        \"@policytype\": \"set\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -106,7 +106,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"4a75736e-001d-4364-8bd4-9888490edb58\",\n    \"accessPolicy\": {\n        \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\"\n    },\n    \"contractPolicy\": {\n        \"uid\": \"956e172f-2de1-4501-8881-057a57fd0e69\"\n    },\n    \"selectorExpression\": {\n        \"criteria\": [\n            {\n                \"left\": \"asset:prop:id\",\n                \"op\": \"IN\",\n                \"right\": [\n                    \"text-document\"\n                ]\n            }\n        ]\n    }\n}",
+							"raw": "{\n    \"id\": \"4a75736e-001d-4364-8bd4-9888490edb56\",\n    \"accessPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n    \"contractPolicyId\": \"956e172f-2de1-4501-8881-057a57fd0e69\",\n        \"criteria\": [\n            {\n                \"left\": \"asset:prop:id\",\n                \"op\": \"=\",\n                \"right\": \"text-document\"\n            }\n        ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -56,6 +56,10 @@ resource "azurerm_container_group" "edc" {
       protocol = "TCP"
     }
     ports {
+      port     = 8282
+      protocol = "TCP"
+    }
+    ports {
       port     = 9191
       protocol = "TCP"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,5 @@
+edcGroup=org.eclipse.dataspaceconnector
 edcVersion=0.0.1-SNAPSHOT
+gatlingVersion=3.7.5
+assertj=3.22.0
+jupiterVersion=5.8.2

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -25,4 +25,6 @@ ENTRYPOINT java \
     -Dweb.http.path="/api" \
     -Dweb.http.data.port="9191" \
     -Dweb.http.data.path="/api/v1/data" \
+    -Dweb.http.ids.port="8282" \
+    -Dweb.http.ids.path="/api/v1/ids" \
     -jar dataspaceconnector-basic.jar

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -19,22 +19,22 @@ plugins {
 }
 
 val edcVersion: String by project
-val group = "org.eclipse.dataspaceconnector"
+val edcGroup: String by project
 
 dependencies {
-    implementation("${group}:core:${edcVersion}")
-    implementation("${group}:ids:${edcVersion}")
-    implementation("${group}:control-api:${edcVersion}")
-    implementation("${group}:observability-api:${edcVersion}")
-    implementation("${group}:data-management-api:${edcVersion}")
-    implementation("${group}:assetindex-memory:${edcVersion}")
-    implementation("${group}:transfer-process-store-memory:${edcVersion}")
-    implementation("${group}:contractnegotiation-store-memory:${edcVersion}")
-    implementation("${group}:contractdefinition-store-memory:${edcVersion}")
-    implementation("${group}:iam-mock:${edcVersion}")
-    implementation("${group}:filesystem-configuration:${edcVersion}")
-    implementation("${group}:http:${edcVersion}")
-    implementation("${group}:policy-store-memory:${edcVersion}")
+    implementation("${edcGroup}:core:${edcVersion}")
+    implementation("${edcGroup}:ids:${edcVersion}")
+    implementation("${edcGroup}:control-api:${edcVersion}")
+    implementation("${edcGroup}:observability-api:${edcVersion}")
+    implementation("${edcGroup}:data-management-api:${edcVersion}")
+    implementation("${edcGroup}:assetindex-memory:${edcVersion}")
+    implementation("${edcGroup}:transfer-process-store-memory:${edcVersion}")
+    implementation("${edcGroup}:contractnegotiation-store-memory:${edcVersion}")
+    implementation("${edcGroup}:contractdefinition-store-memory:${edcVersion}")
+    implementation("${edcGroup}:iam-mock:${edcVersion}")
+    implementation("${edcGroup}:filesystem-configuration:${edcVersion}")
+    implementation("${edcGroup}:http:${edcVersion}")
+    implementation("${edcGroup}:policy-store-memory:${edcVersion}")
 }
 
 application {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "mvd"
 
 include(":launcher")
+include(":system-tests")

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+val edcVersion: String by project
+val edcGroup: String by project
+val gatlingVersion: String by project
+val jupiterVersion: String by project
+val assertj: String by project
+
+dependencies {
+    testImplementation("io.gatling.highcharts:gatling-charts-highcharts:${gatlingVersion}") {
+        exclude(group = "io.gatling", module="gatling-jms")
+        exclude(group = "io.gatling", module="gatling-jms-java")
+        exclude(group = "io.gatling", module="gatling-mqtt")
+        exclude(group = "io.gatling", module="gatling-mqtt-java")
+        exclude(group = "io.gatling", module="gatling-jdbc")
+        exclude(group = "io.gatling", module="gatling-jdbc-java")
+        exclude(group = "io.gatling", module="gatling-redis")
+        exclude(group = "io.gatling", module="gatling-redis-java")
+        exclude(group = "io.gatling", module="gatling-graphite")
+    }
+
+    testImplementation("org.apache.commons:commons-lang3:3.12.0")
+    testImplementation("${edcGroup}:spi:${edcVersion}")
+    testImplementation("org.assertj:assertj-core:${assertj}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
+}
+

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientIntegrationTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.system.tests.remote;
+
+import org.eclipse.dataspaceconnector.system.tests.utils.FileTransferSimulationUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.dataspaceconnector.system.tests.utils.GatlingUtils.runGatling;
+
+/**
+ * Runs {@see FileTransferAsClientSimulation}.
+ */
+public class FileTransferAsClientIntegrationTest {
+
+    @Test
+    public void performFileTransfer() {
+        runGatling(FileTransferAsClientSimulation.class, FileTransferSimulationUtils.DESCRIPTION);
+    }
+}

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientSimulation.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/remote/FileTransferAsClientSimulation.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.system.tests.remote;
+
+import io.gatling.javaapi.core.Simulation;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+import static io.gatling.javaapi.core.CoreDsl.atOnceUsers;
+import static io.gatling.javaapi.core.CoreDsl.global;
+import static io.gatling.javaapi.core.CoreDsl.scenario;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static org.eclipse.dataspaceconnector.system.tests.utils.FileTransferSimulationUtils.DESCRIPTION;
+import static org.eclipse.dataspaceconnector.system.tests.utils.FileTransferSimulationUtils.contractNegotiation;
+
+/**
+ * Runs a single iteration of contract negotiation and file transfer, getting settings from environment variables.
+ */
+public class FileTransferAsClientSimulation extends Simulation {
+
+    public static final String CONSUMER_MANAGEMENT_PATH = "/api/v1/data";
+
+    public FileTransferAsClientSimulation() {
+        setUp(scenario(DESCRIPTION)
+                .repeat(1)
+                .on(
+                        contractNegotiation(getFromEnv("PROVIDER_URL"))
+                )
+                .injectOpen(atOnceUsers(1)))
+                .protocols(http
+                        .baseUrl(getFromEnv("CONSUMER_URL") + "/" + CONSUMER_MANAGEMENT_PATH))
+                .assertions(
+                        global().responseTime().max().lt(2000),
+                        global().successfulRequests().percent().is(100.0)
+                );
+    }
+
+    private static String getFromEnv(String env) {
+        return Objects.requireNonNull(StringUtils.trimToNull(System.getenv(env)), env);
+    }
+}

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/FileTransferSimulationUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/FileTransferSimulationUtils.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.system.tests.utils;
+
+import io.gatling.javaapi.core.ChainBuilder;
+import io.gatling.javaapi.http.HttpRequestActionBuilder;
+import org.eclipse.dataspaceconnector.policy.model.Action;
+import org.eclipse.dataspaceconnector.policy.model.Permission;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.policy.model.PolicyType;
+import org.eclipse.dataspaceconnector.spi.types.TypeManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.contract.negotiation.ContractNegotiationStates;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.gatling.javaapi.core.CoreDsl.StringBody;
+import static io.gatling.javaapi.core.CoreDsl.bodyString;
+import static io.gatling.javaapi.core.CoreDsl.doWhileDuring;
+import static io.gatling.javaapi.core.CoreDsl.exec;
+import static io.gatling.javaapi.core.CoreDsl.group;
+import static io.gatling.javaapi.core.CoreDsl.jmesPath;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static java.lang.String.format;
+
+/**
+ * Utility methods for building a Gatling simulation for performing contract negotiation and file transfer.
+ */
+public abstract class FileTransferSimulationUtils {
+
+    public static final String CONTRACT_AGREEMENT_ID = "contractAgreementId";
+    public static final String CONTRACT_NEGOTIATION_REQUEST_ID = "contractNegotiationRequestId";
+
+    public static final String DESCRIPTION = "[Contract negotiation and file transfer]";
+
+    public static final String PROVIDER_ASSET_NAME = "text-document";
+    private static final String CONTRACT_DEFINITION_ID = "4a75736e-001d-4364-8bd4-9888490edb56";
+
+    private FileTransferSimulationUtils() {
+    }
+
+    /**
+     * Gatling chain for performing contract negotiation.
+     *
+     * @param providerUrl     URL for the Provider API, as accessed from the Consumer runtime.
+     */
+    public static ChainBuilder contractNegotiation(String providerUrl) {
+        return startContractAgreement(providerUrl)
+                .exec(waitForContractAgreement());
+    }
+
+    /**
+     * Gatling chain for initiating a contract negotiation.
+     * <p>
+     * Saves the Contract Negotiation Request ID into the {@see CONTRACT_NEGOTIATION_REQUEST_ID} session key.
+     *
+     * @param providerUrl URL for the Provider API, as accessed from the Consumer runtime.
+     */
+    private static ChainBuilder startContractAgreement(String providerUrl) {
+        var connectorAddress = format("%s/api/v1/ids/data", providerUrl);
+        return group("Contract negotiation")
+                .on(exec(initiateContractNegotiation(connectorAddress)));
+    }
+
+    private static HttpRequestActionBuilder initiateContractNegotiation(String connectorAddress) {
+        return http("Initiate contract negotiation")
+                .post("/contractnegotiations")
+                .body(StringBody(loadContractAgreement(connectorAddress)))
+                .header(CONTENT_TYPE, "application/json")
+                .check(status().is(200))
+                .check(bodyString()
+                        .notNull()
+                        .saveAs(CONTRACT_NEGOTIATION_REQUEST_ID));
+    }
+
+    /**
+     * Gatling chain for calling ContractNegotiation status endpoint repeatedly until a CONFIRMED state is
+     * attained, or a timeout is reached.
+     * <p>
+     * Expects the Contract Negotiation Request ID to be provided in the {@see CONTRACT_NEGOTIATION_REQUEST_ID} session key.
+     * <p>
+     * Saves the Contract Agreement ID into the {@see CONTRACT_AGREEMENT_ID} session key.
+     */
+    private static ChainBuilder waitForContractAgreement() {
+        return exec(session -> session.set("status", -1))
+                .group("Wait for agreement")
+                .on(doWhileDuring(session -> session.getString(CONTRACT_AGREEMENT_ID) == null, Duration.ofSeconds(30))
+                        .on(exec(getContractStatus()).pace(Duration.ofSeconds(1)))
+                );
+    }
+
+    private static HttpRequestActionBuilder getContractStatus() {
+        return http("Get status")
+                .get(session -> format("/contractnegotiations/%s", session.getString(CONTRACT_NEGOTIATION_REQUEST_ID)))
+                .check(status().is(200))
+                .check(
+                        jmesPath("id").is(session -> session.getString(CONTRACT_NEGOTIATION_REQUEST_ID)),
+                        jmesPath("state").saveAs("status")
+                )
+                .checkIf(
+                        session -> ContractNegotiationStates.CONFIRMED.name().equals(session.getString("status"))
+                ).then(
+                        jmesPath("contractAgreementId").notNull().saveAs(CONTRACT_AGREEMENT_ID)
+                );
+    }
+
+    private static String loadContractAgreement(String providerUrl) {
+        var policy = Policy.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .permission(Permission.Builder.newInstance()
+                        .target("text-document")
+                        .action(Action.Builder.newInstance().type("USE").build())
+                        .build())
+                .type(PolicyType.SET)
+                .build();
+        var request = Map.of(
+                "connectorId", "provider",
+                "connectorAddress", providerUrl,
+                "protocol", "ids-multipart",
+                "offer", Map.of(
+                        "offerId", CONTRACT_DEFINITION_ID + ":1",
+                        "assetId", PROVIDER_ASSET_NAME,
+                        "policy", policy
+                )
+        );
+
+        return new TypeManager().writeValueAsString(request);
+    }
+}

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/GatlingUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/GatlingUtils.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.system.tests.utils;
+
+import io.gatling.app.Gatling;
+import io.gatling.core.config.GatlingPropertiesBuilder;
+import io.gatling.javaapi.core.Simulation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Utilities for Gatling tests.
+ */
+public class GatlingUtils {
+
+    /**
+     * Runs a Gatling simulation.
+     *
+     * @param simulation  Gatling simulation class. Must have a public no-args constructor.
+     * @param description Description to be included in HTML report banner.
+     * @throws AssertionError if Gatling assertions fails.
+     */
+    public static void runGatling(Class<? extends Simulation> simulation, String description) {
+        var props = new GatlingPropertiesBuilder();
+        props.simulationClass(simulation.getCanonicalName());
+        props.resultsDirectory("build/reports/gatling");
+        props.runDescription(description);
+
+        var statusCode = Gatling.fromMap(props.build());
+
+        assertThat(statusCode)
+                .withFailMessage("Gatling Simulation failed")
+                .isEqualTo(0);
+    }
+}


### PR DESCRIPTION
System test to validate deployment of two connectors.

- Factored out EDC Maven module cache pre-population into a composite action so it can be used twice (for launcher JAR build and for system tests).
- Bumped EDC version from `milestone-3` to `milestone-3.1` as there are some DTO changes. Adapted Postman assets to fit DTOs.
- Added system test for contract negotiation.

Note that classes are named "FileTransfer" even though file transfer is not yet in scope. This is to keep the same name as in EDC system tests so we can more easily copy over any future changes.

Closes agera-edc/MinimumViableDataspaceFork#97 