### PR TITLE
Use terraform remote state.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -88,6 +88,7 @@ jobs:
             runtime_image = "mvd-edc/connector:${{ github.run_number }}"
             application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           ' >> input.tfvars
+
           terraform init -backend-config=backend.conf
           terraform apply -var-file=input.tfvars -auto-approve
           DID_ENDPOINT=$(terraform output -raw did_endpoint)
@@ -110,12 +111,11 @@ jobs:
           TF_VAR_key_file: "../../key.pem"
           TF_VAR_public_key_jwk_file: "../../key.public.jwk"
 
-      # Publish terraform folder because it contains the state, the provider builds and the input.tfvars file
       - uses: actions/upload-artifact@v3
-        name: 'Publish terraform folder'
+        name: 'Publish Backend conf'
         with:
-          name: terraform-${{ matrix.participant }}
-          path: deployment/terraform
+          name: terraform-${{ matrix.participant }}-backend-conf
+          path: deployment/terraform/backend.conf
           retention-days: 1
 
       - name: 'Verify did endpoint is available'
@@ -163,8 +163,8 @@ jobs:
       - uses: actions/download-artifact@v3
         name: 'Download terraform folder'
         with:
-          name: terraform-${{ matrix.participant }}
-          path: deployment/terraform
+          name: terraform-${{ matrix.participant }}-backend-conf
+          path: deployment/terraform/backend.conf
 
       - name: 'Delete terraform resources'
         run: |
@@ -178,9 +178,3 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-
-      - uses: actions/upload-artifact@v3
-        name: 'Clear terraform artifact'
-        with:
-          name: terraform-${{ matrix.participant }}
-          path: /dev/null

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -74,8 +74,8 @@ jobs:
         run: |
           echo '
             resource_group_name  = "${{ secrets.COMMON_RESOURCE_GROUP }}"
-            storage_account_name = "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
-            container_name       = "${{ secrets.TERRAFORM_STATE_CONTAINER }}
+            storage_account_name = "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}"
+            container_name       = "${{ secrets.TERRAFORM_STATE_CONTAINER }}"
             key                  = "${{ matrix.participant }}${{ github.run_number }}.tfstate"
           ' >> backend.conf
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -162,7 +162,7 @@ jobs:
         name: 'Download terraform folder'
         with:
           name: terraform-${{ matrix.participant }}-backend-conf
-          path: deployment/terraform/backend.conf
+          path: deployment/terraform/
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -169,8 +169,7 @@ jobs:
 
       - name: 'Delete terraform resources'
         run: |
-          : # Make terraform provider binaries executable because file permissions of uploaded artifacts are not maintained.
-          chmod -R +x .terraform/providers
+          terraform init -backend-config=backend.conf
           terraform destroy -var-file=input.tfvars -auto-approve
         working-directory: deployment/terraform
         env:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -159,6 +159,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # Az login is needed to delete the blob terraform state.
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       - uses: actions/download-artifact@v3
         name: 'Download terraform folder'
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -79,18 +79,8 @@ jobs:
             key                  = "${{ matrix.participant }}${{ github.run_number }}.tfstate"
           ' >> backend.conf
 
-          echo '
-            acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
-            acr_name = "${{ secrets.ACR_NAME }}"
-            participant_name = "${{ matrix.participant }}"
-            prefix = "${{ github.run_number }}"
-            resource_group = "rg-${{ matrix.participant }}-${{ github.run_number }}"
-            runtime_image = "mvd-edc/connector:${{ github.run_number }}"
-            application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
-          ' >> input.tfvars
-
           terraform init -backend-config=backend.conf
-          terraform apply -var-file=input.tfvars -auto-approve
+          terraform apply -auto-approve
           DID_ENDPOINT=$(terraform output -raw did_endpoint)
           EDC_HOST=$(terraform output -raw edc_host)
           ASSETS_STORAGE_ACCOUNT=$(terraform output -raw assets_storage_account)
@@ -108,8 +98,16 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+          # Terraform variables.
           TF_VAR_key_file: "../../key.pem"
           TF_VAR_public_key_jwk_file: "../../key.public.jwk"
+          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }
+          TF_VAR_acr_name: ${{ secrets.ACR_NAME }}
+          TF_VAR_participant_name: ${{ matrix.participant }}
+          TF_VAR_prefix: ${{ github.run_number }}
+          TF_VAR_resource_group: rg-${{ matrix.participant }}-${{ github.run_number }}
+          TF_VAR_runtime_image: mvd-edc/connector:${{ github.run_number }}
+          TF_VAR_application_sp_object_id: ${{ secrets.APP_OBJECT_ID }}
 
       - uses: actions/upload-artifact@v3
         name: 'Publish Backend conf'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -77,8 +77,7 @@ jobs:
             storage_account_name = "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
             container_name       = "${{ secrets.TERRAFORM_STATE_CONTAINER }}
             key                  = "${{ matrix.participant }}${{ github.run_number }}.tfstate"
-          '
-          >> backend.conf
+          ' >> backend.conf
 
           echo '
             acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -166,6 +166,7 @@ jobs:
 
       - name: 'Delete terraform resources'
         run: |
+          cat backend.conf
           terraform init -backend-config=backend.conf
           terraform destroy -auto-approve
         working-directory: deployment/terraform

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,7 +101,7 @@ jobs:
           # Terraform variables.
           TF_VAR_key_file: "../../key.pem"
           TF_VAR_public_key_jwk_file: "../../key.public.jwk"
-          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }
+          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
           TF_VAR_acr_name: ${{ secrets.ACR_NAME }}
           TF_VAR_participant_name: ${{ matrix.participant }}
           TF_VAR_prefix: ${{ github.run_number }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: 'Delete terraform resources'
         run: |
           terraform init -backend-config=backend.conf
-          terraform destroy -var-file=input.tfvars -auto-approve
+          terraform destroy -auto-approve
         working-directory: deployment/terraform
         env:
           # Authentication settings for Terraform AzureRM provider

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -72,13 +72,13 @@ jobs:
       - name: 'Run terraform'
         id: runterraform
         run: |
+          # Create backend.conf file to retrieve the remote terraform state during terraform init.
           echo '
             resource_group_name  = "${{ secrets.COMMON_RESOURCE_GROUP }}"
             storage_account_name = "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}"
             container_name       = "${{ secrets.TERRAFORM_STATE_CONTAINER }}"
             key                  = "${{ matrix.participant }}${{ github.run_number }}.tfstate"
           ' >> backend.conf
-
           terraform init -backend-config=backend.conf
           terraform apply -auto-approve
           DID_ENDPOINT=$(terraform output -raw did_endpoint)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -177,5 +177,6 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+          # Passing dummy variables to terraform destroy, because destroy needs input variables to be defined, but uses the state.
           TF_VAR_application_sp_object_id: dummy
           TF_VAR_runtime_image: dummy

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -158,6 +158,7 @@ jobs:
         participant: [company1, company2]
 
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v3
         name: 'Download terraform folder'
         with:
@@ -168,7 +169,7 @@ jobs:
         run: |
           cat backend.conf
           terraform init -backend-config=backend.conf
-          terraform plan
+          terraform destroy -auto-approve
         working-directory: deployment/terraform
         env:
           # Authentication settings for Terraform AzureRM provider

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -73,6 +73,14 @@ jobs:
         id: runterraform
         run: |
           echo '
+            resource_group_name  = "${{ secrets.COMMON_RESOURCE_GROUP }}"
+            storage_account_name = "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
+            container_name       = "${{ secrets.TERRAFORM_STATE_CONTAINER }}
+            key                  = "${{ matrix.participant }}${{ github.run_number }}.tfstate"
+          '
+          >> backend.conf
+
+          echo '
             acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
             acr_name = "${{ secrets.ACR_NAME }}"
             participant_name = "${{ matrix.participant }}"
@@ -81,7 +89,7 @@ jobs:
             runtime_image = "mvd-edc/connector:${{ github.run_number }}"
             application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           ' >> input.tfvars
-          terraform init
+          terraform init -backend-config=backend.conf
           terraform apply -var-file=input.tfvars -auto-approve
           DID_ENDPOINT=$(terraform output -raw did_endpoint)
           EDC_HOST=$(terraform output -raw edc_host)

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -167,7 +167,7 @@ jobs:
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       - uses: actions/download-artifact@v3
-        name: 'Download terraform folder'
+        name: 'Download backend conf'
         with:
           name: terraform-${{ matrix.participant }}-backend-conf
           path: deployment/terraform/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -178,3 +178,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+          TF_VAR_application_sp_object_id: dummy
+          TF_VAR_runtime_image: dummy
+

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -181,4 +181,3 @@ jobs:
 
           TF_VAR_application_sp_object_id: dummy
           TF_VAR_runtime_image: dummy
-

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -167,9 +167,9 @@ jobs:
 
       - name: 'Delete terraform resources'
         run: |
-          cat backend.conf
           terraform init -backend-config=backend.conf
           terraform destroy -auto-approve
+          az storage blob delete --account-name ${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }} -c ${{ secrets.TERRAFORM_STATE_CONTAINER }} -n ${{ matrix.participant }}${{ github.run_number }}.tfstate
         working-directory: deployment/terraform
         env:
           # Authentication settings for Terraform AzureRM provider

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -168,7 +168,7 @@ jobs:
         run: |
           cat backend.conf
           terraform init -backend-config=backend.conf
-          terraform destroy -auto-approve
+          terraform plan
         working-directory: deployment/terraform
         env:
           # Authentication settings for Terraform AzureRM provider

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -16,6 +16,8 @@ jobs:
     env:
       COMMON_RESOURCE_GROUP: ${{ secrets.COMMON_RESOURCE_GROUP }}
       COMMON_RESOURCE_GROUP_LOCATION: ${{ secrets.COMMON_RESOURCE_GROUP_LOCATION }}
+      TERRAFORM_STATE_STORAGE_ACCOUNT: ${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
+      TERRAFORM_STATE_CONTAINER: ${{ secrets.TERRAFORM_STATE_CONTAINER }}
       ACR_NAME: ${{ secrets.ACR_NAME }}
 
     steps:
@@ -28,6 +30,11 @@ jobs:
 
       - name: "Create resource group"
         run: az group create --name "$COMMON_RESOURCE_GROUP" --location "$COMMON_RESOURCE_GROUP_LOCATION" -o table
+
+      - name: "Create terraform state storage account and container"
+        run: |
+          az storage account create --name ${TERRAFORM_STATE_STORAGE_ACCOUNT} --resource-group ${COMMON_RESOURCE_GROUP}
+          az storage container create --name ${TERRAFORM_STATE_CONTAINER} --account-name ${TERRAFORM_STATE_STORAGE_ACCOUNT}
 
       - name: "Create Azure Container Registry"
         run: az acr create --resource-group "$COMMON_RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic --admin-enabled -o table

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -1,8 +1,6 @@
 name: Initialize CD
 
-on:
-  pull_request:
-    branches: [ main ]
+on: workflow_dispatch
 
 # Grant permissions to obtain federated identity credentials
 # see https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -1,6 +1,8 @@
 name: Initialize CD
 
-on: workflow_dispatch
+on:
+  pull_request:
+    branches: [ main ]
 
 # Grant permissions to obtain federated identity credentials
 # see https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -6,12 +6,7 @@ terraform {
     }
   }
 
-  backend "azurerm" {
-    resource_group_name  = var.common_resource_group
-    storage_account_name = var.terraform_state_storage_account
-    container_name       = var.terraform_state_container
-    key                  = "${var.prefix}${var.participant_name}.tfstate"
-  }
+  backend "azurerm" {}
 }
 
 provider "azurerm" {

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -5,6 +5,13 @@ terraform {
       version = ">= 3.1.0"
     }
   }
+
+  backend "azurerm" {
+    resource_group_name  = var.common_resource_group
+    storage_account_name = var.terraform_state_storage_account
+    container_name       = var.terraform_state_container
+    key                  = "${var.prefix}${var.participant_name}.tfstate"
+  }
 }
 
 provider "azurerm" {
@@ -28,7 +35,7 @@ resource "azurerm_resource_group" "participant" {
 
 data "azurerm_container_registry" "registry" {
   name                = var.acr_name
-  resource_group_name = var.acr_resource_group
+  resource_group_name = var.common_resource_group
 }
 
 resource "azurerm_container_group" "edc" {

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_resource_group" "participant" {
 
 data "azurerm_container_registry" "registry" {
   name                = var.acr_name
-  resource_group_name = var.common_resource_group
+  resource_group_name = var.acr_resource_group
 }
 
 resource "azurerm_container_group" "edc" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -22,14 +22,6 @@ variable "common_resource_group" {
   default = "agera-mvd-common"
 }
 
-variable "terraform_state_storage_account" {
-  default = "mvdterraformstates"
-}
-
-variable "terraform_state_container" {
-  default = "mvdterraformstates"
-}
-
 variable "resource_group" {
   default = "test-resource-group"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -18,8 +18,16 @@ variable "acr_name" {
   default = "ageramvd"
 }
 
-variable "acr_resource_group" {
+variable "common_resource_group" {
   default = "agera-mvd-common"
+}
+
+variable "terraform_state_storage_account" {
+  default = "mvdterraformstates"
+}
+
+variable "terraform_state_container" {
+  default = "mvdterraformstates"
 }
 
 variable "resource_group" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "acr_name" {
   default = "ageramvd"
 }
 
-variable "common_resource_group" {
+variable "acr_resource_group" {
   default = "agera-mvd-common"
 }
 

--- a/docs/developer/continuous_deployment.md
+++ b/docs/developer/continuous_deployment.md
@@ -87,6 +87,8 @@ Configure the following GitHub secrets:
 | `COMMON_RESOURCE_GROUP`          | The Azure resource group name to deploy common resources in, such as Azure Container Registry. |
 | `COMMON_RESOURCE_GROUP_LOCATION` | The location of the Azure resource group name to deploy common resources in. Example: `northeurope`. |
 | `ACR_NAME`                    | The name of the Azure Container Registry to deploy. Use only lowercase letters and numbers. |
+| `TERRAFORM_STATE_STORAGE_ACCOUNT` | The name of the storage account used to store the terraform state container. |
+| `TERRAFORM_STATE_CONTAINER` | The name of the container used to store the terraform state blob. |
 
 ### Deploying CD resources
 


### PR DESCRIPTION
- Use terraform remote state instead of publishing state as an artifact.
- Create backend.conf file containing remote state location & publish it as an artifact, to use it for the destroy.
- Delete blob containing the terraform state after destroying terraform resources.

Change on initialize.yaml tested here by changing the trigger temporary: https://github.com/agera-edc/MinimumViableDataspace/runs/6107893856?check_suite_focus=true