### PR TITLE
Specified missing terraform var on destroy.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -266,3 +266,5 @@ jobs:
           TF_VAR_registry_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
           TF_VAR_registry_storage_account: ${{ secrets.REGISTRY_STORAGE_ACCOUNT }}
           TF_VAR_registry_share: ${{ secrets.REGISTRY_SHARE }}
+          TF_VAR_acr_resource_group: ${{ secrets.COMMON_RESOURCE_GROUP }}
+          TF_VAR_acr_name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
Destroy step fails on fork repo because terraform vars `acr_resource_group` and `acr_name` are not specified on destroy. Because of that, default terraform var are used. Then the destroy fails because it cannot find the resource group and the container registry.

This PR fix this problem.