### PR TITLE
Added workflow_dispatch trigger on CD.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'docs/**'
 
+  workflow_dispatch:
+
 # Grant permissions to obtain federated identity credentials
 # see https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure
 permissions:

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -1,0 +1,6 @@
+name: Destroy
+
+on:
+  workflow_dispatch:
+
+jobs:


### PR DESCRIPTION
The user needs to be able to trigger the deploy pipeline manually.
Added workflow_dispatch trigger on CD workflow, to be able to trigger it manually.
The workflow_dispatch trigger needs to be present on the main branch, to be used on other branches.

- Added workflow dispatch trigger workflow to the cd workflow (will be changed to deploy workflow later)
- Added empty destroy workflow that can be triggered manually, to be able to test the destroy workflow and trigger it manually as well.

The goal of this PR is to be able to test the workflows. Because the workflow_dispatch trigger needs to be present on the main branch, to be used on other branches.