### PR TITLE
Feature/65 registry reload

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,8 +59,6 @@ jobs:
       company2_edc_host: ${{ steps.runterraform.outputs.company2_edc_host }}
       company1_key_vault: ${{ steps.runterraform.outputs.company1_key_vault }}
       company2_key_vault: ${{ steps.runterraform.outputs.company2_key_vault }}
-      company1_assets_storage_account: ${{ steps.runterraform.outputs.company1_assets_storage_account }}
-      company2_assets_storage_account: ${{ steps.runterraform.outputs.company2_assets_storage_account }}
       company1_api_key: ${{ steps.runterraform.outputs.company1_api_key }}
       company2_api_key: ${{ steps.runterraform.outputs.company2_api_key }}
 
@@ -103,7 +101,6 @@ jobs:
           echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
           echo "::set-output name=${{ matrix.participant }}_key_vault::${KEY_VAULT}"
           echo "::set-output name=${{ matrix.participant }}_api_key::${API_KEY}"
-          echo "::set-output name=${{ matrix.participant }}_assets_storage_account::${ASSETS_STORAGE_ACCOUNT}"
 
         working-directory: deployment/terraform
         env:
@@ -148,11 +145,6 @@ jobs:
         run: |
           npm install -g newman
           deployment/seed-data.sh
-        env:
-          EDC_HOST: ${{ needs.Deploy.outputs[format('{0}_edc_host', matrix.participant)] }}
-          ASSETS_STORAGE_ACCOUNT: ${{ needs.Deploy.outputs[format('{0}_assets_storage_account', matrix.participant)] }}
-          API_KEY: ${{ needs.Deploy.outputs[format('{0}_api_key', matrix.participant)] }}
-
 
   Verify:
     needs: Deploy

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,10 +59,6 @@ jobs:
       company2_edc_host: ${{ steps.runterraform.outputs.company2_edc_host }}
       company1_key_vault: ${{ steps.runterraform.outputs.company1_key_vault }}
       company2_key_vault: ${{ steps.runterraform.outputs.company2_key_vault }}
-      company1_edc_aci_name: ${{ steps.runterraform.outputs.company1_edc_aci_name }}
-      company2_edc_aci_name: ${{ steps.runterraform.outputs.company2_edc_aci_name }}
-      company1_resource_group: ${{ steps.runterraform.outputs.company1_resource_group }}
-      company2_resource_group: ${{ steps.runterraform.outputs.company2_resource_group }}
       company1_assets_storage_account: ${{ steps.runterraform.outputs.company1_assets_storage_account }}
       company2_assets_storage_account: ${{ steps.runterraform.outputs.company2_assets_storage_account }}
       company1_api_key: ${{ steps.runterraform.outputs.company1_api_key }}
@@ -97,8 +93,6 @@ jobs:
           EDC_HOST=$(terraform output -raw edc_host)
           ASSETS_STORAGE_ACCOUNT=$(terraform output -raw assets_storage_account)
           KEY_VAULT=$(terraform output -raw key_vault)
-          EDC_ACI_NAME=$(terraform output -raw edc_aci_name)
-          RESOURCE_GROUP=$(terraform output -raw resource_group)
           WEBAPP_URL=$(terraform output -raw webapp_url)
           API_KEY=$(terraform output -raw api_key)
           echo "::notice title=MVD WebApp for ${{ matrix.participant }}::$WEBAPP_URL"
@@ -109,8 +103,6 @@ jobs:
           echo "::set-output name=${{ matrix.participant }}_edc_host::${EDC_HOST}"
           echo "::set-output name=${{ matrix.participant }}_key_vault::${KEY_VAULT}"
           echo "::set-output name=${{ matrix.participant }}_api_key::${API_KEY}"
-          echo "::set-output name=${{ matrix.participant }}_edc_aci_name::${EDC_ACI_NAME}"
-          echo "::set-output name=${{ matrix.participant }}_resource_group::${RESOURCE_GROUP}"
           echo "::set-output name=${{ matrix.participant }}_assets_storage_account::${ASSETS_STORAGE_ACCOUNT}"
 
         working-directory: deployment/terraform
@@ -152,40 +144,6 @@ jobs:
       - name: 'Verify deployed EDC is healthy'
         run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
 
-  # Until https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/1230 is done,
-  # connectors must be restarted for catalog to be populated (once registry files have all been stored).
-  # Data must be seeded after restart, since in-memory stores are used.
-  # When that EDC feature is delivered, we can merge this with the Deploy job and seed the data immediately.
-  Seed:
-    needs:
-      - Deploy
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        participant: [company1, company2]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: 'Az CLI login'
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-
-      - name: 'Restart'
-        run: az container restart --name "$EDC_ACI_NAME" --resource-group "$RESOURCE_GROUP"
-        env:
-          EDC_ACI_NAME: ${{ needs.Deploy.outputs[format('{0}_edc_aci_name', matrix.participant)] }}
-          RESOURCE_GROUP: ${{ needs.Deploy.outputs[format('{0}_resource_group', matrix.participant)] }}
-
-      - name: 'Verify deployed EDC is up'
-        run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
-        env:
-          EDC_HOST: ${{ needs.Deploy.outputs[format('{0}_edc_host', matrix.participant)] }}
-
       - name: 'Seed data'
         run: |
           npm install -g newman
@@ -195,10 +153,9 @@ jobs:
           ASSETS_STORAGE_ACCOUNT: ${{ needs.Deploy.outputs[format('{0}_assets_storage_account', matrix.participant)] }}
           API_KEY: ${{ needs.Deploy.outputs[format('{0}_api_key', matrix.participant)] }}
 
+
   Verify:
-    needs:
-      - Deploy
-      - Seed
+    needs: Deploy
     runs-on: ubuntu-latest
     steps:
       # Checkout MVD code

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -170,10 +170,6 @@ jobs:
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
-      # Extra delay to ensure restarted connectors are up. This can be removed after the restart job becomes unnecessary.
-      - name: 'Delay'
-        run: sleep 60
-
       - name: 'System tests'
         run: |
           ./gradlew :system-tests:test

--- a/extensions/refresh-catalog/build.gradle.kts
+++ b/extensions/refresh-catalog/build.gradle.kts
@@ -9,7 +9,7 @@ val mockitoVersion: String by project
 val assertj: String by project
 
 dependencies {
-    api("${edcGroup}:catalog-cache:${edcVersion}")
+    implementation("${edcGroup}:federated-catalog-spi:${edcVersion}")
 
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectory.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Service to ...
+ * Federated cache directory using a set of JSON files as backend.
  */
 class JsonFileBasedNodeDirectory implements FederatedCacheNodeDirectory {
     private final Path nodeJsonDir;

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectory.java
@@ -23,51 +23,34 @@ import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
- * Service to refresh the federated catalog on start-up, using a set of JSON files as input.
+ * Service to ...
  */
-class RefreshCatalogService {
-    private final FederatedCacheNodeDirectory nodeDirectory;
+class JsonFileBasedNodeDirectory implements FederatedCacheNodeDirectory {
     private final Path nodeJsonDir;
     private final String nodeJsonPrefix;
     private final Monitor monitor;
     private final TypeManager typeManager;
 
     /**
-     * Constructs a new instance of {@link RefreshCatalogService}.
+     * Constructs a new instance of {@link JsonFileBasedNodeDirectory}.
      *
-     * @param nodeDirectory  directory service to populate
      * @param nodeJsonDir    directory containing source JSON files
      * @param nodeJsonPrefix prefix to filter source JSON files on
      * @param monitor        monitor service
      * @param typeManager    type manager service
      */
-    RefreshCatalogService(FederatedCacheNodeDirectory nodeDirectory, Path nodeJsonDir, String nodeJsonPrefix, Monitor monitor, TypeManager typeManager) {
+    JsonFileBasedNodeDirectory(Path nodeJsonDir, String nodeJsonPrefix, Monitor monitor, TypeManager typeManager) {
         if (!nodeJsonDir.toFile().isDirectory()) {
             throw new EdcException(nodeJsonDir + " should be a directory");
         }
-        this.nodeDirectory = nodeDirectory;
         this.nodeJsonDir = nodeJsonDir;
         this.nodeJsonPrefix = nodeJsonPrefix;
         this.monitor = monitor;
         this.typeManager = typeManager;
-    }
-
-    /**
-     * Populates federated catalog based on JSON files.
-     */
-    void saveNodeEntries() {
-        try {
-            monitor.info("Refreshing catalog");
-            var files = Files.find(nodeJsonDir, 1,
-                    (path, attrs) -> path.toFile().getName().startsWith(nodeJsonPrefix));
-            files
-                    .map(this::parseFederatedCacheNode)
-                    .forEach(this::insertNode);
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
     }
 
     private FederatedCacheNode parseFederatedCacheNode(Path path) {
@@ -78,10 +61,25 @@ class RefreshCatalogService {
         }
     }
 
-    private void insertNode(FederatedCacheNode node) {
-        monitor.info("Adding catalog node " + node.getName());
-        nodeDirectory.insert(node);
+    /**
+     * Populates federated catalog based on JSON files.
+     */
+    @Override
+    public List<FederatedCacheNode> getAll() {
+        monitor.info("Refreshing catalog");
+        try {
+            var files = Files.find(nodeJsonDir, 1,
+                    (path, attrs) -> path.toFile().getName().startsWith(nodeJsonPrefix));
+            return files
+                    .map(this::parseFederatedCacheNode)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    @Override
+    public void insert(FederatedCacheNode federatedCacheNode) {
+        throw new UnsupportedOperationException();
     }
 }
-
-

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectoryExtension.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectoryExtension.java
@@ -24,10 +24,10 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * Extension to ...
+ * Extension to set up federated cache directory using a set of JSON files as backend.
  */
 @Provides(FederatedCacheNodeDirectory.class)
-public class RefreshCatalogExtension implements ServiceExtension {
+public class JsonFileBasedNodeDirectoryExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RefreshCatalogExtension.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RefreshCatalogExtension.java
@@ -15,7 +15,7 @@
 package org.eclipse.dataspaceconnector.mvd;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provides;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
@@ -24,20 +24,18 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * Extension to refresh the federated catalog on start-up, using a set of JSON files as input.
+ * Extension to ...
  */
+@Provides(FederatedCacheNodeDirectory.class)
 public class RefreshCatalogExtension implements ServiceExtension {
-    @Inject
-    FederatedCacheNodeDirectory nodeDirectory;
-
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
         TypeManager typeManager = context.getTypeManager();
         var nodeJsonPath = Path.of(Objects.requireNonNull(System.getenv("NODES_JSON_DIR"), "Env var NODES_JSON_DIR is null"));
         var nodeJsonPrefix = Objects.requireNonNull(System.getenv("NODES_JSON_FILES_PREFIX"), "Env var NODES_JSON_FILES_PREFIX is null");
-        var service = new RefreshCatalogService(nodeDirectory, nodeJsonPath, nodeJsonPrefix, monitor, typeManager);
-        service.saveNodeEntries();
+        var service = new JsonFileBasedNodeDirectory(nodeJsonPath, nodeJsonPrefix, monitor, typeManager);
+        context.registerService(FederatedCacheNodeDirectory.class, service);
     }
 }
 

--- a/extensions/refresh-catalog/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/refresh-catalog/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,1 +1,1 @@
-org.eclipse.dataspaceconnector.mvd.RefreshCatalogExtension
+org.eclipse.dataspaceconnector.mvd.JsonFileBasedNodeDirectoryExtension

--- a/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectoryTest.java
+++ b/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/JsonFileBasedNodeDirectoryTest.java
@@ -14,35 +14,31 @@
 
 package org.eclipse.dataspaceconnector.mvd;
 
-import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
+import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
 import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
-class RefreshCatalogServiceTest {
+class JsonFileBasedNodeDirectoryTest {
 
     @Test
-    void saveNodeEntries() {
-        var directory = mock(FederatedCacheNodeDirectory.class);
+    void getAll() {
         var sampleFile = getClass().getClassLoader().getResource("24-node1.json");
         assertThat(sampleFile).isNotNull();
         var nodeJsonDir = Path.of(sampleFile.getPath()).getParent();
         var nodeJsonPrefix = "24-";
         var monitor = new ConsoleMonitor();
         var typeManager = new TypeManager();
-        var service = new RefreshCatalogService(directory, nodeJsonDir, nodeJsonPrefix, monitor, typeManager);
+        var service = new JsonFileBasedNodeDirectory(nodeJsonDir, nodeJsonPrefix, monitor, typeManager);
 
-        service.saveNodeEntries();
-
-        verify(directory, times(1)).insert(argThat(n -> "node24-1".equals(n.getName())));
-        verify(directory, times(1)).insert(argThat(n -> "node24-2".equals(n.getName())));
+        List<FederatedCacheNode> cacheNodes = service.getAll();
+        assertThat(cacheNodes).anyMatch(n -> "node24-1".equals(n.getName()));
+        assertThat(cacheNodes).anyMatch(n -> "node24-2".equals(n.getName()));
+        assertThat(cacheNodes).allMatch(n -> n.getName().startsWith("node24-"));
     }
 }

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
 
     // Federated catalog
     implementation("${edcGroup}:catalog-cache:${edcVersion}")
-    implementation("${edcGroup}:catalog-node-directory-memory:${edcVersion}")
     implementation("${edcGroup}:catalog-cache-store-memory:${edcVersion}")
 }
 


### PR DESCRIPTION
Now that https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/1243 got merged upstream, EDC can dynamically reload the registry nodes.

- Changed custom registry extension to reload JSON registry files when the federated catalog refreshes (by default every 10 minutes).
- Removed ACI restart task

Closes agera-edc/MinimumViableDataspaceFork#94 