### PR TITLE
Fix/catalog refresh

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: agera-edc/DataSpaceConnector
         path: DataSpaceConnector
-        ref: feature/1183/231-azure-e2e-test
+        ref: 8561416a1fbeacca21f574aa56e76a071a287e75
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -118,8 +118,8 @@ resource "azurerm_container_group" "edc" {
       NODES_JSON_FILES_PREFIX = local.registry_files_prefix
 
       # Refresh catalog frequently to accelerate scenarios
-      EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS  = 1
-      EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS = 1
+      EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS  = 10
+      EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS = 10
     }
 
     secure_environment_variables = {

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -117,6 +117,7 @@ resource "azurerm_container_group" "edc" {
       NODES_JSON_DIR          = "/registry"
       NODES_JSON_FILES_PREFIX = local.registry_files_prefix
 
+      # Refresh catalog frequently to accelerate scenarios
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS  = 1
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS = 1
     }

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -56,6 +56,8 @@ locals {
 
   connector_id = "urn:connector:${var.prefix}-${var.participant_name}"
 
+  did_url = "did:web:${azurerm_storage_account.did.primary_web_host}:identity"
+
   edc_dns_label       = "${var.prefix}-${var.participant_name}-edc-mvd"
   edc_default_port    = 8181
   edc_ids_port        = 8282
@@ -114,6 +116,9 @@ resource "azurerm_container_group" "edc" {
 
       NODES_JSON_DIR          = "/registry"
       NODES_JSON_FILES_PREFIX = local.registry_files_prefix
+
+      EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS  = 1
+      EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS = 1
     }
 
     secure_environment_variables = {
@@ -272,20 +277,20 @@ resource "azurerm_storage_blob" "did" {
   storage_account_name = azurerm_storage_account.did.name
   # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
   count                  = var.public_key_jwk_file == null ? 0 : 1
-  storage_container_name = "$web"
+  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
   type                   = "Block"
   source_content = jsonencode({
-    id = "did:web:${azurerm_storage_account.did.primary_web_host}:identity",
+    id = local.did_url
     "@context" = ["https://www.w3.org/ns/did/v1",
       {
-        "@base" = "did:web:${azurerm_storage_account.did.primary_web_host}:identity"
+        "@base" = local.did_url
       }
     ],
     "verificationMethod" = [
       {
-        "id"           = "#identity-key-1",
-        "controller"   = "",
-        "type"         = "JsonWebKey2020",
+        "id"           = "#identity-key-1"
+        "controller"   = ""
+        "type"         = "JsonWebKey2020"
         "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file))
       }
     ],

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -28,14 +28,9 @@ dependencies {
     implementation("${edcGroup}:control-api:${edcVersion}")
     implementation("${edcGroup}:observability-api:${edcVersion}")
     implementation("${edcGroup}:data-management-api:${edcVersion}")
-    implementation("${edcGroup}:assetindex-memory:${edcVersion}")
-    implementation("${edcGroup}:transfer-process-store-memory:${edcVersion}")
-    implementation("${edcGroup}:contractnegotiation-store-memory:${edcVersion}")
-    implementation("${edcGroup}:contractdefinition-store-memory:${edcVersion}")
     implementation("${edcGroup}:iam-mock:${edcVersion}")
     implementation("${edcGroup}:filesystem-configuration:${edcVersion}")
     implementation("${edcGroup}:http:${edcVersion}")
-    implementation("${edcGroup}:policy-store-memory:${edcVersion}")
 
     // API key authentication (also used for CORS support)
     implementation("${edcGroup}:auth-tokenbased:${edcVersion}")
@@ -54,7 +49,6 @@ dependencies {
 
     // Federated catalog
     implementation("${edcGroup}:catalog-cache:${edcVersion}")
-    implementation("${edcGroup}:catalog-cache-store-memory:${edcVersion}")
 }
 
 application {


### PR DESCRIPTION
Updated EDC dependencies to include newly merged changes upstream.
- Removed in-memory store dependencies (these are now provided by default in EDC).
- Increased catalog refresh frequency from 10 minutes to 1 second to accelerate multi-party scenarios.

Unrelated, I also included a few style improvements in terraform files.