### PR TITLE
Bug/135 connector name

### DIFF
--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -326,7 +326,7 @@ resource "local_file" "registry_entry" {
   content = jsonencode({
     # `name` must be identical to EDC connector EDC_CONNECTOR_NAME setting for catalog asset filtering to
     # exclude assets from own connector.
-    name               = local.connector_id,
+    name               = local.connector_name,
     url                = "http://${azurerm_container_group.edc.fqdn}:${local.edc_ids_port}",
     supportedProtocols = ["ids-multipart"]
   })

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -326,7 +326,7 @@ resource "local_file" "registry_entry" {
   content = jsonencode({
     # `name` must be identical to EDC connector EDC_CONNECTOR_NAME setting for catalog asset filtering to
     # exclude assets from own connector.
-    name               = local.connector_name,
+    name               = local.connector_id,
     url                = "http://${azurerm_container_group.edc.fqdn}:${local.edc_ids_port}",
     supportedProtocols = ["ids-multipart"]
   })


### PR DESCRIPTION
Use the correct value for connector name, so that catalog nodes are properly filtered.

A comment to that effect was actually already in the file, but the implementation did not follow it.

Closes agera-edc/MinimumViableDataspaceFork#67 