### PR TITLE
Spike: run MVD locally

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -33,7 +33,7 @@ runs:
     # This action only runs if the packages could not be restored from the cache.
     - name: Build EDC packages
       run: |
-        ./gradlew publishToMavenLocal
+        ./gradlew publishToMavenLocal -Pskip.signing
       if: steps.cache.outputs.cache-hit != 'true' # only on cache miss
       shell: bash
       working-directory: DataSpaceConnector

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Checkout EDC
       uses: actions/checkout@v2
       with:
-        repository: agera-edc/DataSpaceConnector
+        repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: 8561416a1fbeacca21f574aa56e76a071a287e75
+        ref: main
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ hs_err_pid*
 build
 
 .idea
+.run
 .vs
 .vscode
 

--- a/deployment/dockercompose/README.md
+++ b/deployment/dockercompose/README.md
@@ -1,0 +1,6 @@
+this directory contains JSON files that make up the Federated Cache Node Directory
+and it should be used for running the MVD using `docker-compose`.
+Note that the `docker-compose.yaml` is located in the root directory, and should then define the following environment variables:
+
+- `NODES_JSON_DIR`: path to this directory
+- `NODES_JSON_FILES_PREFIX`: prefix for all files in this directory, should be `test-`

--- a/deployment/dockercompose/test-company1.json
+++ b/deployment/dockercompose/test-company1.json
@@ -1,0 +1,5 @@
+{
+  "name": "connector-company1",
+  "supportedProtocols": ["ids-multipart"],
+  "url": "http://company1:8282"
+}

--- a/deployment/dockercompose/test-company2.json
+++ b/deployment/dockercompose/test-company2.json
@@ -1,0 +1,5 @@
+{
+  "name": "connector-company2",
+  "supportedProtocols": ["ids-multipart"],
+  "url": "http://company2:8282"
+}

--- a/deployment/dockercompose/test-company3.json
+++ b/deployment/dockercompose/test-company3.json
@@ -1,0 +1,7 @@
+{
+  "name": "connector-company3",
+  "supportedProtocols": [
+    "ids-multipart"
+  ],
+  "url": "http://company3:8282"
+}

--- a/deployment/local/README.md
+++ b/deployment/local/README.md
@@ -1,0 +1,5 @@
+this directory contains JSON files that make up the Federated Cache Node Directory
+and it should be used for running the MVD using IntelliJ.
+The following environment variables will have to be set:
+- `NODES_JSON_DIR`: path to this directory
+- `NODES_JSON_FILES_PREFIX`: prefix for all files in this directory, should be `test-`

--- a/deployment/local/test-company1.json
+++ b/deployment/local/test-company1.json
@@ -1,0 +1,5 @@
+{
+  "name": "connector-company1",
+  "supportedProtocols": ["ids-multipart"],
+  "url": "http://localhost:8282"
+}

--- a/deployment/local/test-company2.json
+++ b/deployment/local/test-company2.json
@@ -1,0 +1,5 @@
+{
+  "name": "connector-company2",
+  "supportedProtocols": ["ids-multipart"],
+  "url": "http://localhost:18282"
+}

--- a/deployment/local/test-company3.json
+++ b/deployment/local/test-company3.json
@@ -1,0 +1,7 @@
+{
+  "name": "connector-company3",
+  "supportedProtocols": [
+    "ids-multipart"
+  ],
+  "url": "http://localhost:28282"
+}

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -164,7 +164,7 @@ resource "azurerm_container_group" "webapp" {
 
   container {
     name   = "webapp"
-    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/dashboard:${var.data_dashboard_image_tag}"
+    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/data-dashboard:${var.data_dashboard_image_tag}"
     cpu    = 1
     memory = 1
 

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -164,7 +164,7 @@ resource "azurerm_container_group" "webapp" {
 
   container {
     name   = "webapp"
-    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/data-dashboard:${var.data_dashboard_image_tag}"
+    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/dashboard:${var.data_dashboard_image_tag}"
     cpu    = 1
     memory = 1
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -8,14 +8,14 @@ variable "participant_name" {
 }
 
 variable "participant_region" {
-  default = "westeurope"
+  default = "northeurope"
 }
 
 variable "runtime_image" {
 }
 
 variable "location" {
-  default = "westeurope"
+  default = "northeurope"
 }
 
 variable "acr_name" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -8,14 +8,14 @@ variable "participant_name" {
 }
 
 variable "participant_region" {
-  default = "eu"
+  default = "westeurope"
 }
 
 variable "runtime_image" {
 }
 
 variable "location" {
-  default = "northeurope"
+  default = "westeurope"
 }
 
 variable "acr_name" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -8,7 +8,7 @@ variable "participant_name" {
 }
 
 variable "participant_region" {
-  default = "northeurope"
+  default = "eu"
 }
 
 variable "runtime_image" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -74,7 +74,7 @@ variable "registry_share" {
 
 variable "data_dashboard_image_tag" {
   description = "tag of the Data Dashboard web app image to deploy"
-  default     = "847c9dd40e0d2dc75818351718ea4d348ce202b5"
+  default     = "latest"
 }
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,49 @@
+# Docker-compose file to run MVD locally, for demo or debug purposes
+# note that environment variables for all three connectors must be declared in an .env file!
+version: "3.9"
+services:
+  company1:
+    env_file:
+      - company1.env
+    container_name: company1
+    build:
+      context: launcher
+      dockerfile: Dockerfile
+    ports:
+      - "8181:8181"
+      - "9191:9191"
+      - "8282:8282"
+    volumes:
+      - type: bind
+        source: ./deployment/dockercompose
+        target: /registry
+  company2:
+    env_file:
+      - company2.env
+    container_name: company2
+    build:
+      context: launcher
+      dockerfile: Dockerfile
+    ports:
+      - "18181:8181"
+      - "19191:9191"
+      - "18282:8282"
+    volumes:
+      - type: bind
+        source: ./deployment/dockercompose
+        target: /registry
+  company3:
+    env_file:
+      - company3.env
+    container_name: company3
+    build:
+      context: launcher
+      dockerfile: Dockerfile
+    ports:
+      - "28181:8181"
+      - "29191:9191"
+      - "28282:8282"
+    volumes:
+      - type: bind
+        source: ./deployment/dockercompose
+        target: /registry

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -11,15 +11,10 @@ EXPOSE 8181
 EXPOSE 9191
 EXPOSE 8282
 
+RUN apt update && apt install curl -y
+
 # health status is determined by the availability of the /health endpoint
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail -X GET http://localhost:8181/api/check/health || exit 1
-
-ENV WEB_HTTP_PORT="8181"
-ENV WEB_HTTP_PATH="/api"
-ENV WEB_HTTP_DATA_PORT="9191"
-ENV WEB_HTTP_DATA_PATH="/api/v1/data"
-ENV WEB_HTTP_IDS_PORT="8282"
-ENV WEB_HTTP_IDS_PATH="/api/v1/ids"
 
 # Use "exec" for graceful termination (SIGINT) to reach JVM.
 ENTRYPOINT [ "sh", "-c", \

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(project(":extensions:mock-credentials-verifier"))
     implementation("${edcGroup}:core:${edcVersion}")
     implementation("${edcGroup}:ids:${edcVersion}")
-    implementation("${edcGroup}:control-api:${edcVersion}")
     implementation("${edcGroup}:observability-api:${edcVersion}")
     implementation("${edcGroup}:data-management-api:${edcVersion}")
     implementation("${edcGroup}:filesystem-configuration:${edcVersion}")


### PR DESCRIPTION
This PR adds two things:
- running MVD locally using docker compose
- running MVD from IntelliJ

for docker-compose: 
- create `*.env` files that contain all necessary environment variables, name them `company[1|2|3].env` and put them in the root directory of the project
- the `NODES_JSON_DIR` env var must point to `/registry`, because that's where the volume mapping points to.
- run `./gradlew clean shadowJar`, then `docker-compose build` and `docker-compose up` to start MVD locally.

for IntelliJ (good for debugging):
- when creating a launch config, let the `NODES_JSON_DIR` enviroment variable point to `./deployment/local`

**Note: there are a few changes to the CI pipeline in this PR --> pls ignore those.**