### PR TITLE
Feature/85 build dashboard

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,7 +74,7 @@ jobs:
     env:
       ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
-      - name: Checkout EDC
+      - name: Checkout EDCDataDashboard
         uses: actions/checkout@v2
         with:
           repository: agera-edc/EDCDataDashboard

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -137,6 +137,7 @@ jobs:
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ matrix.participant }}-${{ env.RESOURCES_PREFIX }}"
           runtime_image = "mvd-edc/connector:${{ env.RESOURCES_PREFIX }}"
+          dashboard_image = "mvd-edc/data-dashboard:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,8 +38,10 @@ jobs:
           echo "::set-output name=matrix::$matrix"
 
   # Build runtime image in Azure Container Registry, tagged with the unique run_number.
-  Build:
+  Build-Connector:
     runs-on: ubuntu-latest
+    env:
+      ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
       # Checkout MVD code
       - uses: actions/checkout@v2
@@ -53,28 +55,50 @@ jobs:
 
       - name: 'Login to ACR'
         run: az acr login -n $ACR_NAME
-        env:
-          ACR_NAME: ${{ secrets.ACR_NAME }}
 
       - uses: ./.github/actions/gradle-setup
 
       # Build MVD runtime JAR locally.
       # The result is a JAR file in MVD/launcher/build/libs.
       - name: 'Build runtime JAR'
-        run: |
-          ./gradlew launcher:shadowJar
+        run: ./gradlew launcher:shadowJar
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
         run: az acr build --registry $ACR_NAME --image mvd-edc/connector:${{ env.RESOURCES_PREFIX }} .
         working-directory: launcher
-        env:
-          ACR_NAME: ${{ secrets.ACR_NAME }}
+
+  # Build data dashboard webapp
+  Build-Dashboard:
+    runs-on: ubuntu-latest
+    env:
+      ACR_NAME: ${{ secrets.ACR_NAME }}
+    steps:
+      - name: Checkout EDC
+        uses: actions/checkout@v2
+        with:
+          repository: agera-edc/EDCDataDashboard
+          ref: 6657d71bca844e0c2fc0a01081b8fd97628d522f
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Login to ACR'
+        run: az acr login -n $ACR_NAME
+
+      # Build Docker runtime image remotely on ACR & push it to the registry.
+      - name: 'Build image'
+        run: az acr build --registry $ACR_NAME --image mvd-edc/data-dashboard:${{ env.RESOURCES_PREFIX }} .
 
   # Deploy dataspace participants in parallel.
   Deploy:
     needs:
-      - Build
+      - Build-Connector
+      - Build-Dashboard
       - Matrix
     runs-on: ubuntu-latest
     outputs:

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -164,7 +164,7 @@ resource "azurerm_container_group" "webapp" {
 
   container {
     name   = "webapp"
-    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/data-dashboard:${var.runtime_image}"
+    image  = "${data.azurerm_container_registry.registry.login_server}/${var.dashboard_image}"
     cpu    = 1
     memory = 1
 

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -164,7 +164,7 @@ resource "azurerm_container_group" "webapp" {
 
   container {
     name   = "webapp"
-    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/data-dashboard:${var.data_dashboard_image_tag}"
+    image  = "${data.azurerm_container_registry.registry.login_server}/mvd-edc/data-dashboard:${var.runtime_image}"
     cpu    = 1
     memory = 1
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -71,10 +71,3 @@ variable "registry_storage_account" {
 variable "registry_share" {
   description = "name of the registry JSON documents file share"
 }
-
-variable "data_dashboard_image_tag" {
-  description = "tag of the Data Dashboard web app image to deploy"
-  default     = "5396bfc0a1c5672e1858d2e9da3f374a436b19dc"
-}
-
-

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -14,6 +14,9 @@ variable "participant_region" {
 variable "runtime_image" {
 }
 
+variable "dashboard_image" {
+}
+
 variable "location" {
   default = "northeurope"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -12,9 +12,11 @@ variable "participant_region" {
 }
 
 variable "runtime_image" {
+  description = "Image name of the EDC Connector to deploy"
 }
 
 variable "dashboard_image" {
+  description = "Image name of the Data Dashboard web app to deploy"
 }
 
 variable "location" {


### PR DESCRIPTION
Build the dashboard in the MVD CD pipeline so that users can fork and deploy MVD without additional steps.

The instructions for forking do not need to be updated, as they will work as documented with this change.

Closes agera-edc/MinimumViableDataspaceFork#82 