### PR TITLE
Fix/tfvars blob

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Upload tfvars file'
-        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
+        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ matrix.participant }}${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
 
       - name: 'Run terraform'
         id: runterraform

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,16 +120,10 @@ jobs:
           registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
           registry_share = "${{ secrets.REGISTRY_SHARE }}"
           EOF
-
-      - name: 'Az CLI login'
-        uses: azure/login@v1
+      - uses: actions/upload-artifact@v3
         with:
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-
-      - name: 'Upload tfvars file'
-        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
+          name: terraform-variables-${{ env.RESOURCES_PREFIX }}-${{ matrix.participant }}
+          path: deployment/terraform/terraform.tfvars
 
       - name: 'Run terraform'
         id: runterraform

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Upload tfvars file'
-        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode login
+        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
 
       - name: 'Run terraform'
         id: runterraform

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,7 +129,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Upload tfvars file'
-        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
+        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode login
 
       - name: 'Run terraform'
         id: runterraform

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,10 +120,16 @@ jobs:
           registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
           registry_share = "${{ secrets.REGISTRY_SHARE }}"
           EOF
-      - uses: actions/upload-artifact@v3
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
         with:
-          name: terraform-variables-${{ env.RESOURCES_PREFIX }}-${{ matrix.participant }}
-          path: deployment/terraform/terraform.tfvars
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Upload tfvars file'
+        run: az storage blob upload --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
 
       - name: 'Run terraform'
         id: runterraform

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -55,7 +55,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Download tfvars file'
-        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
+        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode login
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -47,15 +47,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: terraform-variables-${{ env.RESOURCES_PREFIX }}-${{ matrix.participant }}
+          path: deployment/terraform
+
+      # Az login is needed to delete the blob terraform state.
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-
-      - name: 'Download tfvars file'
-        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -47,18 +47,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: terraform-variables-${{ env.RESOURCES_PREFIX }}-${{ matrix.participant }}
-          path: deployment/terraform
-
-      # Az login is needed to delete the blob terraform state.
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Download tfvars file'
+        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars"
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -55,7 +55,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Download tfvars file'
-        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode login
+        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -55,7 +55,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: 'Download tfvars file'
-        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
+        run: az storage blob download --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -f deployment/terraform/terraform.tfvars -n "${{ matrix.participant }}${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
 
       - name: 'Delete terraform resources'
         run: |

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -68,7 +68,6 @@ jobs:
           ' >> backend.conf
           terraform init -backend-config=backend.conf
           terraform destroy -auto-approve
-          az storage blob delete --account-name ${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }} -c ${{ secrets.TERRAFORM_STATE_CONTAINER }} -n ${{ matrix.participant }}${RESOURCES_PREFIX}.tfstate
         working-directory: deployment/terraform
         env:
           # Authentication settings for Terraform AzureRM provider
@@ -80,3 +79,8 @@ jobs:
 
           # Passing dummy variables to terraform destroy, because destroy needs input variables to be defined, but uses the state.
           TF_VAR_application_sp_client_secret: dummy
+
+      - name: 'Delete state and tfvars blobs'
+        run: |
+          az storage blob delete --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -n "${{ matrix.participant }}${{ env.RESOURCES_PREFIX }}.tfvars" --auth-mode key
+          az storage blob delete --account-name "${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}" -c "${{ secrets.TERRAFORM_STATE_CONTAINER }}" -n "${{ matrix.participant }}${{ env.RESOURCES_PREFIX }}.tfstate" --auth-mode key

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ You might need to delete the DataSpace created previously.
 - Provide the resources prefix that you used when you deployed your DataSpace.
 - Click on `Run workflow` to trigger to destroy your MinimumViableDataspace DataSpace.
 
-Note that the GitHub Artifacts by the Destroy pipeline are only retained for the [default time period](https://docs.github.com/actions/using-workflows/storing-workflow-data-as-artifacts#about-workflow-artifacts) which is currently 90 days. If destroying a deployment after that period, the pipeline will fail. In that case, manually delete the provisioned Azure resource groups.
-
 ## Local development setup
 
 Please follow the instructions in [this document](system-tests/README.md) to setup a local MVD environment for development purposes.


### PR DESCRIPTION
Use a storage account to store TF variables instead of using a github action artifact, so that we can run the deploy and destroy pipeline manually.

Manual pipelines tested:
- https://github.com/agera-edc/MinimumViableDataspace/actions/runs/2415006644
- https://github.com/agera-edc/MinimumViableDataspace/runs/6670962986?check_suite_focus=true

Closes agera-edc/MinimumViableDataspaceFork#28 