### PR TITLE
Fix crawler for MVD asset publishing

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: db34d77bc86c0013a6f98208fd14f62ff9549dcb
+        ref: 5191d3e6dd9ac5d78264d05ae69edb4d297b606a
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -25,11 +25,16 @@ dependencies {
     implementation(project(":extensions:refresh-catalog"))
     implementation(project(":extensions:mock-credentials-verifier"))
     implementation("${edcGroup}:core:${edcVersion}")
-    implementation("${edcGroup}:ids:${edcVersion}")
     implementation("${edcGroup}:observability-api:${edcVersion}")
     implementation("${edcGroup}:data-management-api:${edcVersion}")
     implementation("${edcGroup}:filesystem-configuration:${edcVersion}")
     implementation("${edcGroup}:http:${edcVersion}")
+
+    // IDS
+    implementation("${edcGroup}:ids:${edcVersion}") {
+        // Workaround for https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/1387
+        exclude(group = edcGroup, module = "ids-token-validation")
+    }
 
     // API key authentication for Data Management API (also used for CORS support)
     implementation("${edcGroup}:auth-tokenbased:${edcVersion}")


### PR DESCRIPTION
Bump EDC version to include fix https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/1374, which caused federated catalog crawler to crash.

Closes agera-edc/MinimumViableDataspaceFork#39 