### PR TITLE
Deploy registration service in MVD

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -103,7 +103,7 @@ jobs:
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
-        run: az acr build --registry $ACR_NAME --image mvd/registration-service:${{ env.RESOURCES_PREFIX }} .
+        run: az acr build --registry $ACR_NAME --image mvd-edc/registration-service:${{ env.RESOURCES_PREFIX }} .
         working-directory: launcher
 
   # Build data dashboard webapp
@@ -150,8 +150,14 @@ jobs:
       - name: 'Create tfvars file'
         run: |
           cat > terraform.tfvars <<EOF
+          acr_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
+          acr_name = "${{ secrets.ACR_NAME }}"
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
+          runtime_image = "mvd-edc/registration-service:${{ env.RESOURCES_PREFIX }}"
+          registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
+          registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
+          registry_share = "${{ secrets.REGISTRY_SHARE }}"
           EOF
 
       - name: 'Az CLI login'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -152,7 +152,7 @@ jobs:
           acr_name = "${{ secrets.ACR_NAME }}"
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
-          runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
+          registry_runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
           registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
           registry_share = "${{ secrets.REGISTRY_SHARE }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -193,9 +193,6 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
-      - name: 'Verify deployed Registry Service is healthy'
-        run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
-
   # Deploy dataspace participants in parallel.
   Deploy-Participants:
     needs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -195,7 +195,7 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
       - name: 'Verify deployed Registry Service is healthy'
-        run: curl --retry 6 --fail http://${REGISTRY_HOST}:8181/api/health
+        run: curl --retry 6 --fail http://${REGISTRY_HOST}:8181/api/check/health
 
   # Deploy dataspace participants in parallel.
   Deploy-Participants:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,9 +74,6 @@ jobs:
     env:
       ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
-      # Checkout MVD code
-      - uses: actions/checkout@v2
-
       # Checkout Registration service code
       - name: Checkout EDC
         uses: actions/checkout@v2
@@ -198,7 +195,7 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
       - name: 'Verify deployed Registry Service is healthy'
-          run: curl --retry 6 --fail http://${REGISTRY_HOST}:8181/api/health
+        run: curl --retry 6 --fail http://${REGISTRY_HOST}:8181/api/health
 
   # Deploy dataspace participants in parallel.
   Deploy-Participants:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,7 +75,7 @@ jobs:
       ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
       # Checkout Registration service code
-      - name: Checkout EDC
+      - name: Checkout Registration Service
         uses: actions/checkout@v2
         with:
           repository: agera-edc/RegistrationService

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,6 +68,44 @@ jobs:
         run: az acr build --registry $ACR_NAME --image mvd-edc/connector:${{ env.RESOURCES_PREFIX }} .
         working-directory: launcher
 
+  # Build runtime image in Azure Container Registry, tagged with the unique run_number.
+  Build-Registration-Service:
+    runs-on: ubuntu-latest
+    env:
+      ACR_NAME: ${{ secrets.ACR_NAME }}
+    steps:
+      # Checkout MVD code
+      - uses: actions/checkout@v2
+
+      # Checkout Registration service code
+      - name: Checkout EDC
+        uses: actions/checkout@v2
+        with:
+          repository: agera-edc/RegistrationService
+          ref: d9f81a3736efb38e47f48d7da0c749653001f0b4
+
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: 'Login to ACR'
+        run: az acr login -n $ACR_NAME
+
+      - uses: ./.github/actions/gradle-setup
+
+      # Build Registration Service runtime JAR locally.
+      # The result is a JAR file in launcher/build/libs.
+      - name: 'Build runtime JAR'
+        run: ./gradlew launcher:shadowJar
+
+      # Build Docker runtime image remotely on ACR & push it to the registry.
+      - name: 'Build image'
+        run: az acr build --registry $ACR_NAME --image mvd/registration-service:${{ env.RESOURCES_PREFIX }} .
+        working-directory: launcher
+
   # Build data dashboard webapp
   Build-Dashboard:
     runs-on: ubuntu-latest
@@ -96,6 +134,8 @@ jobs:
 
   # Deploy shared dataspace components.
   Deploy-Dataspace:
+    needs:
+      - Build-Registration-Service
     runs-on: ubuntu-latest
     outputs:
       app_insights_connection_string: ${{ steps.runterraform.outputs.app_insights_connection_string }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
-        run: az acr build --registry $ACR_NAME --image mvd-edc/connector:${{ env.RESOURCES_PREFIX }} .
+        run: az acr build --registry $ACR_NAME --image mvd/connector:${{ env.RESOURCES_PREFIX }} .
         working-directory: launcher
 
   # Build runtime image in Azure Container Registry, tagged with the unique run_number.
@@ -103,7 +103,7 @@ jobs:
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
-        run: az acr build --registry $ACR_NAME --image mvd-edc/registration-service:${{ env.RESOURCES_PREFIX }} .
+        run: az acr build --registry $ACR_NAME --image mvd/registration-service:${{ env.RESOURCES_PREFIX }} .
         working-directory: launcher
 
   # Build data dashboard webapp
@@ -130,7 +130,7 @@ jobs:
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
-        run: az acr build --registry $ACR_NAME --image mvd-edc/data-dashboard:${{ env.RESOURCES_PREFIX }} .
+        run: az acr build --registry $ACR_NAME --image mvd/data-dashboard:${{ env.RESOURCES_PREFIX }} .
 
   # Deploy shared dataspace components.
   Deploy-Dataspace:
@@ -154,7 +154,7 @@ jobs:
           acr_name = "${{ secrets.ACR_NAME }}"
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
-          runtime_image = "mvd-edc/registration-service:${{ env.RESOURCES_PREFIX }}"
+          runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
           registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
           registry_share = "${{ secrets.REGISTRY_SHARE }}"
@@ -247,8 +247,8 @@ jobs:
           data_dashboard_theme = "${{ matrix.data_dashboard_theme }}"
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ matrix.participant }}-${{ env.RESOURCES_PREFIX }}"
-          runtime_image = "mvd-edc/connector:${{ env.RESOURCES_PREFIX }}"
-          dashboard_image = "mvd-edc/data-dashboard:${{ env.RESOURCES_PREFIX }}"
+          runtime_image = "mvd/connector:${{ env.RESOURCES_PREFIX }}"
+          dashboard_image = "mvd/data-dashboard:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -193,6 +193,9 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
+      - name: 'Verify deployed Registry Service is healthy'
+        run: curl --retry 6 --fail http://${EDC_HOST}:8181/api/check/health
+
   # Deploy dataspace participants in parallel.
   Deploy-Participants:
     needs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       app_insights_connection_string: ${{ steps.runterraform.outputs.app_insights_connection_string }}
+      registry_host: ${{ steps.runterraform.outputs.registry_host }}
 
     defaults:
       run:
@@ -184,6 +185,9 @@ jobs:
           terraform apply -auto-approve
           app_insights_connection_string=$(terraform output -raw app_insights_connection_string)
           echo "::set-output name=app_insights_connection_string::${app_insights_connection_string}"
+          REGISTRY_HOST=$(terraform output -raw registry_host)
+          echo "REGISTRY_HOST=$REGISTRY_HOST" >> $GITHUB_ENV
+          echo "::set-output name=registry_host::${REGISTRY_HOST}"
 
         env:
           # Authentication settings for Terraform AzureRM provider
@@ -192,6 +196,9 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+      - name: 'Verify deployed Registry Service is healthy'
+          run: curl --retry 6 --fail http://${REGISTRY_HOST}:8181/api/health
 
   # Deploy dataspace participants in parallel.
   Deploy-Participants:

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -27,6 +27,30 @@ data "azurerm_subscription" "current_subscription" {
 data "azurerm_client_config" "current_client" {
 }
 
+data "azurerm_container_registry" "registry" {
+  name                = var.acr_name
+  resource_group_name = var.acr_resource_group
+}
+
+data "azurerm_storage_account" "registry" {
+  name                = var.registry_storage_account
+  resource_group_name = var.registry_resource_group
+}
+
+data "azurerm_storage_share" "registry" {
+  name                 = var.registry_share
+  storage_account_name = data.azurerm_storage_account.registry.name
+}
+
+locals {
+  registry_files_prefix = "${var.prefix}-"
+
+  connector_name = "connector-registry"
+
+  registry_service_dns_label = "${var.prefix}-registry-mvd"
+  edc_default_port           = 8181
+}
+
 resource "azurerm_resource_group" "dataspace" {
   name     = var.resource_group
   location = var.location
@@ -37,5 +61,54 @@ resource "azurerm_application_insights" "dataspace" {
   location            = var.location
   resource_group_name = azurerm_resource_group.dataspace.name
   application_type    = "java"
+}
+
+resource "azurerm_container_group" "registry-service" {
+  name                = "${var.prefix}-registry"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.dataspace.name
+  ip_address_type     = "Public"
+  dns_name_label      = local.registry_service_dns_label
+  os_type             = "Linux"
+
+  image_registry_credential {
+    username = data.azurerm_container_registry.registry.admin_username
+    password = data.azurerm_container_registry.registry.admin_password
+    server   = data.azurerm_container_registry.registry.login_server
+  }
+
+  container {
+    name   = "registry-service"
+    image  = "${data.azurerm_container_registry.registry.login_server}/${var.runtime_image}"
+    cpu    = var.container_cpu
+    memory = var.container_memory
+
+    ports {
+      port     = local.edc_default_port
+      protocol = "TCP"
+    }
+
+    environment_variables = {
+      EDC_CONNECTOR_NAME = local.connector_name
+
+      NODES_JSON_DIR          = "/registry"
+      NODES_JSON_FILES_PREFIX = local.registry_files_prefix
+    }
+
+    volume {
+      storage_account_name = data.azurerm_storage_account.registry.name
+      storage_account_key  = data.azurerm_storage_account.registry.primary_access_key
+      share_name           = data.azurerm_storage_share.registry.name
+      mount_path           = "/registry"
+      name                 = "registry"
+    }
+
+    liveness_probe {
+      http_get {
+        port = 8181
+        path = "/api/check/health"
+      }
+    }
+  }
 }
 

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -79,7 +79,7 @@ resource "azurerm_container_group" "registry-service" {
 
   container {
     name   = "registry-service"
-    image  = "${data.azurerm_container_registry.registry.login_server}/${var.runtime_image}"
+    image  = "${data.azurerm_container_registry.registry.login_server}/${var.registry_runtime_image}"
     cpu    = var.container_cpu
     memory = var.container_memory
 

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -2,3 +2,7 @@ output "app_insights_connection_string" {
   value     = azurerm_application_insights.dataspace.connection_string
   sensitive = true
 }
+
+output "registry_host" {
+  value = azurerm_container_group.registry-service.fqdn
+}

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -28,7 +28,7 @@ variable "container_cpu" {
 }
 
 variable "container_memory" {
-  default = "1.5"
+  default = "8"
 }
 
 variable "registry_resource_group" {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -12,7 +12,7 @@ variable "resource_group" {
 }
 
 variable "registry_runtime_image" {
-  description = "Image name of the Registry Service to deploy"
+  description = "Image name of the Registry Service to deploy."
 }
 
 variable "acr_name" {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -11,8 +11,8 @@ variable "resource_group" {
   default = "test-dataspace"
 }
 
-variable "runtime_image" {
-  description = "Image name of the EDC Connector to deploy"
+variable "registry_runtime_image" {
+  description = "Image name of the Registry Service to deploy"
 }
 
 variable "acr_name" {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -36,7 +36,7 @@ variable "registry_resource_group" {
 }
 
 variable "registry_storage_account" {
-  description = "name of the registry JSON documents file share storage account"
+  description = "name of the registration service storage account"
 }
 
 variable "registry_share" {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -32,7 +32,7 @@ variable "container_memory" {
 }
 
 variable "registry_resource_group" {
-  description = "resource group of the registry JSON documents file share storage account"
+  description = "resource group of the registration service"
 }
 
 variable "registry_storage_account" {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -10,3 +10,36 @@ variable "location" {
 variable "resource_group" {
   default = "test-dataspace"
 }
+
+variable "runtime_image" {
+  description = "Image name of the EDC Connector to deploy"
+}
+
+variable "acr_name" {
+  default = "ageramvd"
+}
+
+variable "acr_resource_group" {
+  default = "agera-mvd-common"
+}
+
+variable "container_cpu" {
+  default = "0.5"
+}
+
+variable "container_memory" {
+  default = "1.5"
+}
+
+variable "registry_resource_group" {
+  description = "resource group of the registry JSON documents file share storage account"
+}
+
+variable "registry_storage_account" {
+  description = "name of the registry JSON documents file share storage account"
+}
+
+variable "registry_share" {
+  description = "name of the registry JSON documents file share"
+}
+

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -31,11 +31,6 @@ locals {
   api_key = random_password.apikey.result
 }
 
-resource "azurerm_resource_group" "participant" {
-  name     = var.resource_group
-  location = var.location
-}
-
 data "azurerm_container_registry" "registry" {
   name                = var.acr_name
   resource_group_name = var.acr_resource_group
@@ -64,6 +59,11 @@ locals {
   edc_default_port    = 8181
   edc_ids_port        = 8282
   edc_management_port = 9191
+}
+
+resource "azurerm_resource_group" "participant" {
+  name     = var.resource_group
+  location = var.location
 }
 
 resource "azurerm_container_group" "edc" {

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -40,7 +40,7 @@ variable "container_cpu" {
 }
 
 variable "container_memory" {
-  default = "1.5"
+  default = "8"
 }
 
 variable "application_sp_object_id" {

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -65,6 +65,7 @@ variable "public_key_jwk_file" {
   description = "name of a file containing the public key in JWK format"
   default     = null
 }
+
 variable "registry_resource_group" {
   description = "resource group of the registry JSON documents file share storage account"
 }

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -40,7 +40,7 @@ variable "container_cpu" {
 }
 
 variable "container_memory" {
-  default = "8"
+  default = "1.5"
 }
 
 variable "application_sp_object_id" {


### PR DESCRIPTION
Closes agera-edc/MinimumViableDataspaceFork#50

During an initial MVD dataspace deployment registration service needs to be deployed. Later if we add more participants then they can be onboarded using deployed registration service.

- Update MVD deployment to build and deploy registration service.
- Registration service container deployment already has registry file share mounted (for agera-edc/MinimumViableDataspaceFork#49)
- some changes in names/resource order in terraform files for consistency
