### PR TITLE
Feature: use snapshot builds instead of local builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ allprojects {
         mavenLocal()
         // prepare for switch to using pinned snapshot builds
         maven {
-+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-+        }
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+         }
         maven {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,10 @@ allprojects {
     repositories {
         mavenCentral()
         mavenLocal()
+        // prepare for switch to using pinned snapshot builds
+        maven {
++            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
++        }
         maven {
             url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
         }


### PR DESCRIPTION
this PR adds the OSSRH snapshot repo as preparation when we want to make the switch